### PR TITLE
Add localization support for day and month names using date-fns locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The `Calendar` component accepts the following props:
   
 - `onCellHeaderClick`: A callback function that is called when a cell header is clicked. It receives the clicked cell date information and _event_ as a parameter. It is the part to the left and right of the day number within cell. In the case of a MONTH and WEEK views, `onCellClick` method will be called instead of this one.
 
+- `locale` _(DEFAULT: enUS)_: Accepts a locale object from the `date-fns` library. It controls the language used for displaying the names of days and months in the calendar.
+
 - `cellDisplayMode`: An object that controls the display mode of the cells in the calendar. It should have the following structure:
   - `[CURRENT_VIEW]`: The current view of the calendar (e.g., `WEEK_TIME`, `DAY`, `MONTH`, etc.).
     - `inactiveCells`: An array of inactive cell dates that should be hidden.

--- a/src/components/Calendar/Calendar.helper.ts
+++ b/src/components/Calendar/Calendar.helper.ts
@@ -27,6 +27,7 @@ import {
   isEmptyObject,
 } from '../../utils/index';
 import { TimeDateFormat } from './Calendar.constants';
+import enUS from 'date-fns/locale/en-US';
 
 // Designed to prepare and display the hours on the left side of the calendar
 export const getTimeUnitString = (
@@ -174,6 +175,7 @@ export const initializeProps = ({
   currentView,
   activeTimeDateField,
   data,
+  locale,
 }: InitializePropsFunc): InitializePropsRetFunc => {
   const onDayNumberClickModified = onDayNumberClick || (() => null);
   const onDayStringClickModified = onDayStringClick || (() => null);
@@ -193,6 +195,7 @@ export const initializeProps = ({
   const currentViewModified = (currentView as CurrentView) || CurrentView.MONTH;
   const activeTimeDateFieldModified = activeTimeDateField || '';
   const dataModified = data || [];
+  const localeModified = locale || enUS;
   const cellDisplayModeConst = {
     MONTH: {
       inactiveCells: [],
@@ -229,6 +232,7 @@ export const initializeProps = ({
     currentViewModified,
     activeTimeDateFieldModified,
     dataModified,
+    localeModified,
   };
 };
 

--- a/src/components/Calendar/Calendar.types.ts
+++ b/src/components/Calendar/Calendar.types.ts
@@ -1,3 +1,5 @@
+import { Locale } from 'date-fns';
+
 export interface DateInfo {
   isCurrentDay: boolean;
   isCurrentMonth?: boolean;
@@ -135,6 +137,7 @@ export interface CalendarProps {
   ) => void;
   timeDateFormat: TimeFormatModified;
   weekStartsOn: WeekStartsOn;
+  locale: Locale;
 }
 
 export interface CalendarWrapperProps {
@@ -187,6 +190,7 @@ export interface CalendarWrapperProps {
   ) => void;
   timeDateFormat?: TimeFormat;
   weekStartsOn?: WeekStartsOn | number;
+  locale?: Locale;
 }
 
 export interface CalendarHeaderProps {
@@ -194,6 +198,7 @@ export interface CalendarHeaderProps {
   currentView: CurrentView;
   currentDate: string | Date;
   timeDateFormat: TimeFormatModified;
+  locale: Locale;
 }
 
 export interface CalculateStartAndEndMinuteFunc {
@@ -239,6 +244,7 @@ export interface InitializePropsFunc {
   activeTimeDateField?: string;
   // eslint-disable-next-line
   data?: Record<string, any>[];
+  locale?: Locale;
 }
 export interface InitializePropsRetFunc {
   cellDisplayModeModified: CellDisplayMode;
@@ -275,4 +281,5 @@ export interface InitializePropsRetFunc {
   activeTimeDateFieldModified: string;
   // eslint-disable-next-line
   dataModified: Record<string, any>[];
+  localeModified: Locale;
 }

--- a/src/components/Calendar/CalendarComponent.tsx
+++ b/src/components/Calendar/CalendarComponent.tsx
@@ -25,6 +25,7 @@ const CalendarComponent: FC<CalendarProps> = ({
   onCellHeaderClick,
   timeDateFormat,
   weekStartsOn,
+  locale,
 }) => {
   // Object that will be used to display the color dot for each day, but also for the legend below the calendar
   const preparedColorDots: ColorDotFull = useMemo(() => {
@@ -52,6 +53,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           currentView={currentView}
           setCurrentDate={setCurrentDate}
           timeDateFormat={timeDateFormat}
+          locale={locale}
         />
       )}
       {currentView === CurrentView.MONTH && (
@@ -66,6 +68,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           onCellClick={onCellClick}
           timeDateFormat={timeDateFormat}
           weekStartsOn={weekStartsOn}
+          locale={locale}
         />
       )}
       {currentView === CurrentView.WEEK && (
@@ -79,6 +82,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           onCellClick={onCellClick}
           timeDateFormat={timeDateFormat}
           weekStartsOn={weekStartsOn}
+          locale={locale}
         />
       )}
       {currentView === CurrentView.WEEK_TIME && (
@@ -95,6 +99,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           timeDateFormat={timeDateFormat}
           onHourClick={onHourClick}
           weekStartsOn={weekStartsOn}
+          locale={locale}
         />
       )}
       {currentView === CurrentView.DAY && (
@@ -110,6 +115,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           onCellHeaderClick={onCellHeaderClick}
           timeDateFormat={timeDateFormat}
           onHourClick={onHourClick}
+          locale={locale}
         />
       )}
       {currentView === CurrentView.DAY_REVERSE && (
@@ -123,6 +129,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           onCellClick={onCellClick}
           timeDateFormat={timeDateFormat}
           onHourClick={onHourClick}
+          locale={locale}
         />
       )}
       {currentView === CurrentView.WEEK_IN_PLACE && (
@@ -138,6 +145,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           timeDateFormat={timeDateFormat}
           onHourClick={onHourClick}
           weekStartsOn={weekStartsOn}
+          locale={locale}
         />
       )}
       {currentView === CurrentView.DAY_IN_PLACE && (
@@ -152,6 +160,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           onCellHeaderClick={onCellHeaderClick}
           timeDateFormat={timeDateFormat}
           onHourClick={onHourClick}
+          locale={locale}
         />
       )}
       {!isEmptyObject(preparedColorDots) && (

--- a/src/components/Calendar/CalendarNavigation.tsx
+++ b/src/components/Calendar/CalendarNavigation.tsx
@@ -10,6 +10,7 @@ const CalendarNavigation: React.FC<CalendarHeaderProps> = ({
   currentDate,
   currentView,
   timeDateFormat,
+  locale,
 }) => {
   const getNextTimeUnit = React.useMemo(() => {
     switch (currentView) {
@@ -64,6 +65,7 @@ const CalendarNavigation: React.FC<CalendarHeaderProps> = ({
           {format(
             new Date(currentDate),
             timeDateFormat?.monthYear || TimeDateFormat.MONTH_YEAR,
+            { locale },
           )}
         </span>
       </div>

--- a/src/components/Calendar/CalendarWrapper.tsx
+++ b/src/components/Calendar/CalendarWrapper.tsx
@@ -50,6 +50,7 @@ const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
   onCellHeaderClick,
   timeDateFormat,
   weekStartsOn,
+  locale,
 }) => {
   // Preparing the data to work for all cases
   const {
@@ -67,6 +68,7 @@ const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
     currentViewModified,
     dataModified,
     activeTimeDateFieldModified,
+    localeModified,
   } = initializeProps({
     cellDisplayMode,
     timeDateFormat,
@@ -82,6 +84,7 @@ const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
     currentView,
     activeTimeDateField,
     data,
+    locale,
   });
 
   const [hoveredElement, setHoveredElement] = React.useState(0);
@@ -406,6 +409,7 @@ const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
         onCellHeaderClick={onCellHeaderClickModified}
         timeDateFormat={timeDateFormatModified}
         weekStartsOn={weekStartsOnModified}
+        locale={localeModified}
       />
     </>
   );

--- a/src/components/Calendar/DayInPlaceView/DayInPlaceView.tsx
+++ b/src/components/Calendar/DayInPlaceView/DayInPlaceView.tsx
@@ -30,6 +30,7 @@ const DayInPlaceView: FC<DayInPlaceViewProps> = ({
   onCellHeaderClick,
   timeDateFormat,
   preparedColorDots,
+  locale,
 }) => {
   // Current day info
   const parsedCurrentDay = useMemo(() => {
@@ -46,6 +47,7 @@ const DayInPlaceView: FC<DayInPlaceViewProps> = ({
           {format(
             new Date(currentDate),
             timeDateFormat.day || TimeDateFormat.SHORT_WEEKDAY,
+            { locale },
           )}
         </div>
       </div>

--- a/src/components/Calendar/DayInPlaceView/DayInPlaceView.types.tsx
+++ b/src/components/Calendar/DayInPlaceView/DayInPlaceView.types.tsx
@@ -1,3 +1,4 @@
+import { Locale } from 'date-fns';
 import {
   ColorDot,
   ColorDotFull,
@@ -33,4 +34,5 @@ export interface DayInPlaceViewProps {
     value: DateInfo | number,
     event: React.MouseEvent<HTMLElement>,
   ) => void;
+  locale: Locale;
 }

--- a/src/components/Calendar/DayReverseView/DayReverseView.tsx
+++ b/src/components/Calendar/DayReverseView/DayReverseView.tsx
@@ -36,6 +36,7 @@ const DayReverseView: FC<DayReverseTimeViewProps> = ({
   onCellClick,
   timeDateFormat,
   preparedColorDots,
+  locale,
 }) => {
   // Current day info
   const parsedCurrentDay = useMemo(() => {
@@ -53,6 +54,7 @@ const DayReverseView: FC<DayReverseTimeViewProps> = ({
           {format(
             new Date(currentDate),
             timeDateFormat.day || TimeDateFormat.SHORT_WEEKDAY,
+            { locale },
           )}
         </div>
         <p

--- a/src/components/Calendar/DayReverseView/DayReverseView.types.ts
+++ b/src/components/Calendar/DayReverseView/DayReverseView.types.ts
@@ -1,3 +1,4 @@
+import { Locale } from 'date-fns';
 import {
   ColorDot,
   ColorDotFull,
@@ -25,4 +26,5 @@ export interface DayReverseTimeViewProps {
     value: DateInfo | number,
     event: React.MouseEvent<HTMLElement>,
   ) => void;
+  locale: Locale;
 }

--- a/src/components/Calendar/DayView/DayView.tsx
+++ b/src/components/Calendar/DayView/DayView.tsx
@@ -38,6 +38,7 @@ const DayView: FC<DayTimeViewProps> = ({
   onCellHeaderClick,
   timeDateFormat,
   preparedColorDots,
+  locale,
 }) => {
   // Current day info
   const parsedCurrentDay = useMemo(() => {
@@ -54,6 +55,7 @@ const DayView: FC<DayTimeViewProps> = ({
           {format(
             new Date(currentDate),
             timeDateFormat.day || TimeDateFormat.SHORT_WEEKDAY,
+            { locale },
           )}
         </div>
       </div>

--- a/src/components/Calendar/DayView/DayView.types.ts
+++ b/src/components/Calendar/DayView/DayView.types.ts
@@ -1,3 +1,4 @@
+import { Locale } from 'date-fns';
 import {
   ColorDot,
   ColorDotFull,
@@ -33,4 +34,5 @@ export interface DayTimeViewProps {
     value: DateInfo | number,
     event: React.MouseEvent<HTMLElement>,
   ) => void;
+  locale: Locale;
 }

--- a/src/components/Calendar/MonthView/MonthVIew.types.ts
+++ b/src/components/Calendar/MonthView/MonthVIew.types.ts
@@ -1,3 +1,4 @@
+import { Locale } from 'date-fns';
 import {
   ColorDot,
   ColorDotFull,
@@ -25,4 +26,5 @@ export interface MonthViewProps {
   timeDateFormat: TimeFormatModified;
   preparedColorDots: ColorDotFull;
   weekStartsOn: WeekStartsOn;
+  locale: Locale;
 }

--- a/src/components/Calendar/MonthView/MonthView.tsx
+++ b/src/components/Calendar/MonthView/MonthView.tsx
@@ -39,6 +39,7 @@ const MonthView: FC<MonthViewProps> = ({
   timeDateFormat,
   preparedColorDots,
   weekStartsOn,
+  locale,
 }) => {
   // It is necessary to render the rows (weeks) that are visible in the viewport
   const [visibleWeeks, setVisibleWeeks] = useState<number[]>([0]);
@@ -134,6 +135,7 @@ const MonthView: FC<MonthViewProps> = ({
                 days: i,
               }),
               timeDateFormat.day,
+              { locale },
             )}
           </div>
         ))}

--- a/src/components/Calendar/WeekTimeInPlaceView/WeekTimeInPlaceView.tsx
+++ b/src/components/Calendar/WeekTimeInPlaceView/WeekTimeInPlaceView.tsx
@@ -43,6 +43,7 @@ const WeekTimeInPlaceView: FC<WeekInPlaceViewProps> = ({
   timeDateFormat,
   preparedColorDots,
   weekStartsOn,
+  locale,
 }) => {
   // Returns every day of the week
   const getCurrentWeek = useMemo(() => {
@@ -90,6 +91,7 @@ const WeekTimeInPlaceView: FC<WeekInPlaceViewProps> = ({
                 days: i,
               }),
               timeDateFormat.day,
+              { locale },
             )}
           </div>
         ))}

--- a/src/components/Calendar/WeekTimeInPlaceView/WeekTimeInPlaceView.types.ts
+++ b/src/components/Calendar/WeekTimeInPlaceView/WeekTimeInPlaceView.types.ts
@@ -1,3 +1,4 @@
+import { Locale } from 'date-fns';
 import {
   ColorDot,
   ColorDotFull,
@@ -35,4 +36,5 @@ export interface WeekInPlaceViewProps {
     event: React.MouseEvent<HTMLElement>,
   ) => void;
   weekStartsOn: WeekStartsOn;
+  locale: Locale;
 }

--- a/src/components/Calendar/WeekTimeView/WeekTimeView.tsx
+++ b/src/components/Calendar/WeekTimeView/WeekTimeView.tsx
@@ -46,6 +46,7 @@ const WeekTimeView: FC<WeekTimeViewProps> = ({
   timeDateFormat,
   preparedColorDots,
   weekStartsOn,
+  locale,
 }) => {
   // Returns every day of the week
   const getCurrentWeek = useMemo(() => {
@@ -90,6 +91,7 @@ const WeekTimeView: FC<WeekTimeViewProps> = ({
                 days: i,
               }),
               timeDateFormat.day,
+              { locale },
             )}
           </div>
         ))}

--- a/src/components/Calendar/WeekTimeView/WeekTimeView.types.ts
+++ b/src/components/Calendar/WeekTimeView/WeekTimeView.types.ts
@@ -1,3 +1,4 @@
+import { Locale } from 'date-fns';
 import {
   ColorDot,
   ColorDotFull,
@@ -35,4 +36,5 @@ export interface WeekTimeViewProps {
     event: React.MouseEvent<HTMLElement>,
   ) => void;
   weekStartsOn: WeekStartsOn;
+  locale: Locale;
 }

--- a/src/components/Calendar/WeekView/WeekView.tsx
+++ b/src/components/Calendar/WeekView/WeekView.tsx
@@ -37,6 +37,7 @@ const WeekView: FC<WeekViewProps> = ({
   timeDateFormat,
   preparedColorDots,
   weekStartsOn,
+  locale,
 }) => {
   // Returns every day of the week
   const getCurrentWeek = useMemo(() => {
@@ -82,6 +83,7 @@ const WeekView: FC<WeekViewProps> = ({
                 days: i,
               }),
               timeDateFormat.day,
+              { locale },
             )}
           </div>
         ))}

--- a/src/components/Calendar/WeekView/WeekView.types.ts
+++ b/src/components/Calendar/WeekView/WeekView.types.ts
@@ -1,3 +1,4 @@
+import { Locale } from 'date-fns';
 import {
   ColorDot,
   ColorDotFull,
@@ -23,4 +24,5 @@ export interface WeekViewProps {
   timeDateFormat: TimeFormatModified;
   preparedColorDots: ColorDotFull;
   weekStartsOn: WeekStartsOn;
+  locale: Locale;
 }


### PR DESCRIPTION
## Lack of Feature:
Prior to this update, the react-lightweight-calendar was limited to displaying day and month names in English only. Integrating a localization feature enhances the calendar's versatility and accessibility, making it more user-friendly for non-English speaking users.

## Implementation Details:
This pull request introduces localization support for day and month names in the calendar. The implementation leverages the existing `date-fns` library, which the project already uses for date parsing. The core of this update is the addition of a `locale` prop, which is passed to the `format` function from date-fns. By setting the locale prop on the calendar component, and utilizing one of the pre-existing locale objects from date-fns, the calendar now automatically displays day and month names in the specified locale.

## Usage Example:
To use this new feature, simply import a locale from date-fns and pass it as a prop to the react-lightweight-calendar component. For example:

```javascript
import Calendar from 'react-lightweight-calendar';
import { es } from 'date-fns/locale'; // Spanish locale

function MyApp() {
  return (
    <Calendar locale={es} />
  );
}
```

In this example, the calendar will display day and month names in Spanish. This update significantly improves the flexibility of the calendar, making it a more suitable option for applications with multilingual requirements.