### PR TITLE
Add todayLabel customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Access any component by **className** and apply whatever style you want
 ```jsx
 import React from 'react';
 import Calendar from 'react-lightweight-calendar';
+import { enUS } from 'date-fns/locale';
 
 const MyCalendar = () => {
   const [currentDate, setCurrentDate] = React.useState('2023-06-02');
@@ -207,6 +208,8 @@ const MyCalendar = () => {
         hour: 'hh a',
         monthYear: 'LLLL yyyy',
       }}
+      locale={enUS}
+      todayLabel="Go to today"
       onDayNumberClick={(day) => {
         // Handle day number click
         console.log(day);

--- a/src/components/Calendar/Calendar.helper.ts
+++ b/src/components/Calendar/Calendar.helper.ts
@@ -6,6 +6,15 @@ import {
   getMinutes,
   startOfWeek,
 } from 'date-fns';
+import enUS from 'date-fns/locale/en-US';
+import {
+  dayInWeekBasedOnWeekStarts,
+  formatFullDate,
+  formatFullDateTime,
+  getAllDaysInMonth,
+  isEmptyObject,
+} from '../../utils/index';
+import { TimeDateFormat } from './Calendar.constants';
 import {
   CalculateStartAndEndMinuteFunc,
   CellDisplayMode,
@@ -19,15 +28,6 @@ import {
   TimeFormat,
   WeekStartsOn,
 } from './Calendar.types';
-import {
-  dayInWeekBasedOnWeekStarts,
-  formatFullDate,
-  formatFullDateTime,
-  getAllDaysInMonth,
-  isEmptyObject,
-} from '../../utils/index';
-import { TimeDateFormat } from './Calendar.constants';
-import enUS from 'date-fns/locale/en-US';
 
 // Designed to prepare and display the hours on the left side of the calendar
 export const getTimeUnitString = (
@@ -176,6 +176,7 @@ export const initializeProps = ({
   activeTimeDateField,
   data,
   locale,
+  todayLabel,
 }: InitializePropsFunc): InitializePropsRetFunc => {
   const onDayNumberClickModified = onDayNumberClick || (() => null);
   const onDayStringClickModified = onDayStringClick || (() => null);
@@ -196,6 +197,7 @@ export const initializeProps = ({
   const activeTimeDateFieldModified = activeTimeDateField || '';
   const dataModified = data || [];
   const localeModified = locale || enUS;
+  const todayLabelModified = todayLabel || 'Today';
   const cellDisplayModeConst = {
     MONTH: {
       inactiveCells: [],
@@ -233,6 +235,7 @@ export const initializeProps = ({
     activeTimeDateFieldModified,
     dataModified,
     localeModified,
+    todayLabelModified,
   };
 };
 

--- a/src/components/Calendar/Calendar.stories.tsx
+++ b/src/components/Calendar/Calendar.stories.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
 import { Story } from '@storybook/react';
+import { enUS } from 'date-fns/locale';
 import Prism from 'prismjs';
 import 'prismjs/themes/prism-twilight.css';
+import React from 'react';
+import { colorDots, testData } from '../../dataProps';
 import Styleguide from '../StyleGuide/StyleGuide';
-import CalendarWrapper from './CalendarWrapper';
 import {
   CalendarWrapperProps,
   CellDisplayModeState,
   CurrentView,
   WeekStartsOn,
 } from './Calendar.types';
-import { colorDots, testData } from '../../dataProps';
+import CalendarWrapper from './CalendarWrapper';
 
 export default {
   title: 'UI Components/Calendar',
@@ -79,6 +80,8 @@ const codeSnippet = Prism.highlight(
       hour: 'string', // Hour on the left side of the calendar
       monthYear: 'string', // Text in navigation
     }}
+    locale={enUS} // Locale object from the date-fns library
+    todayLabel="Today" // Label for the "Today" button
     onDayNumberClick={(day: string, event: React.MouseEvent<HTMLElement>) => void} // A callback method that is called by clicking on day number
     onDayStringClick={(day: string | Date, event: React.MouseEvent<HTMLElement>) => void} // A callback method that is called by clicking on day text
     onHourClick={(value: DateInfo | number, event: React.MouseEvent<HTMLElement>) => void} // A callback method that is called by clicking on hour on left side of Calendar
@@ -132,6 +135,8 @@ const Template: Story<CalendarWrapperProps> = (args) => {
         colorDots={argsData.colorDots}
         timeDateFormat={argsData.timeDateFormat}
         cellDisplayMode={argsData.cellDisplayMode}
+        locale={enUS}
+        todayLabel="Today"
       />
 
       <br />
@@ -176,4 +181,6 @@ Calendar.args = {
       state: CellDisplayModeState.CUSTOM,
     },
   },
+  locale: enUS,
+  todayLabel: 'Today',
 };

--- a/src/components/Calendar/Calendar.types.ts
+++ b/src/components/Calendar/Calendar.types.ts
@@ -191,6 +191,7 @@ export interface CalendarWrapperProps {
   timeDateFormat?: TimeFormat;
   weekStartsOn?: WeekStartsOn | number;
   locale?: Locale;
+  todayLabel?: string;
 }
 
 export interface CalendarHeaderProps {
@@ -199,6 +200,7 @@ export interface CalendarHeaderProps {
   currentDate: string | Date;
   timeDateFormat: TimeFormatModified;
   locale: Locale;
+  todayLabel?: string;
 }
 
 export interface CalculateStartAndEndMinuteFunc {
@@ -245,6 +247,7 @@ export interface InitializePropsFunc {
   // eslint-disable-next-line
   data?: Record<string, any>[];
   locale?: Locale;
+  todayLabel?: string;
 }
 export interface InitializePropsRetFunc {
   cellDisplayModeModified: CellDisplayMode;
@@ -282,4 +285,5 @@ export interface InitializePropsRetFunc {
   // eslint-disable-next-line
   dataModified: Record<string, any>[];
   localeModified: Locale;
+  todayLabelModified: string;
 }

--- a/src/components/Calendar/CalendarComponent.tsx
+++ b/src/components/Calendar/CalendarComponent.tsx
@@ -1,14 +1,14 @@
-import React, { FC, useMemo } from 'react';
-import { CalendarProps, ColorDotFull, CurrentView } from './Calendar.types';
-import MonthView from './MonthView/MonthView';
-import WeekView from './WeekView/WeekView';
-import CalendarNavigation from './CalendarNavigation';
-import WeekTimeView from './WeekTimeView/WeekTimeView';
-import DayView from './DayView/DayView';
-import DayInPlaceView from './DayInPlaceView/DayInPlaceView';
-import WeekTimeInPlaceView from './WeekTimeInPlaceView/WeekTimeInPlaceView';
+import { FC, useMemo } from 'react';
 import { isEmptyObject } from '../../utils';
+import { CalendarProps, ColorDotFull, CurrentView } from './Calendar.types';
+import CalendarNavigation from './CalendarNavigation';
+import DayInPlaceView from './DayInPlaceView/DayInPlaceView';
 import DayReverseView from './DayReverseView/DayReverseView';
+import DayView from './DayView/DayView';
+import MonthView from './MonthView/MonthView';
+import WeekTimeInPlaceView from './WeekTimeInPlaceView/WeekTimeInPlaceView';
+import WeekTimeView from './WeekTimeView/WeekTimeView';
+import WeekView from './WeekView/WeekView';
 
 const CalendarComponent: FC<CalendarProps> = ({
   renderItems,
@@ -26,6 +26,7 @@ const CalendarComponent: FC<CalendarProps> = ({
   timeDateFormat,
   weekStartsOn,
   locale,
+  todayLabel,
 }) => {
   // Object that will be used to display the color dot for each day, but also for the legend below the calendar
   const preparedColorDots: ColorDotFull = useMemo(() => {
@@ -54,6 +55,7 @@ const CalendarComponent: FC<CalendarProps> = ({
           setCurrentDate={setCurrentDate}
           timeDateFormat={timeDateFormat}
           locale={locale}
+          todayLabel={todayLabel}
         />
       )}
       {currentView === CurrentView.MONTH && (

--- a/src/components/Calendar/CalendarNavigation.tsx
+++ b/src/components/Calendar/CalendarNavigation.tsx
@@ -1,9 +1,9 @@
+import { add, format, sub } from 'date-fns';
 import React from 'react';
 import { formatFullDate } from '../../utils/index';
-import { add, sub, format } from 'date-fns';
 import Button from '../Button/Button';
-import { CalendarHeaderProps, CurrentView } from './Calendar.types';
 import { TimeDateFormat } from './Calendar.constants';
+import { CalendarHeaderProps, CurrentView } from './Calendar.types';
 
 const CalendarNavigation: React.FC<CalendarHeaderProps> = ({
   setCurrentDate,
@@ -11,6 +11,7 @@ const CalendarNavigation: React.FC<CalendarHeaderProps> = ({
   currentView,
   timeDateFormat,
   locale,
+  todayLabel,
 }) => {
   const getNextTimeUnit = React.useMemo(() => {
     switch (currentView) {
@@ -43,7 +44,7 @@ const CalendarNavigation: React.FC<CalendarHeaderProps> = ({
     <div data-cy="CalendarNavigation" className="calendar__navigation">
       <Button
         dataCy="NavigationNowButton"
-        label="Today"
+        label={todayLabel}
         onClick={() => setCurrentDate(formatFullDate(new Date()))}
         withBorder
       />

--- a/src/components/Calendar/CalendarWrapper.tsx
+++ b/src/components/Calendar/CalendarWrapper.tsx
@@ -1,13 +1,6 @@
-import React, { ReactElement } from 'react';
 import cn from 'classnames';
-import {
-  CalendarWrapperProps,
-  CurrentView,
-  DateInfoFunction,
-  PreparedDataWithTimeFull,
-  PreparedDataWithTimeInPlace,
-  PreparedDataWithoutTime,
-} from './Calendar.types';
+import React, { ReactElement } from 'react';
+import '../../styles/styles.scss';
 import {
   formatFullDate,
   formatHour,
@@ -17,16 +10,23 @@ import {
   prepareCalendarDataWithTime,
   prepareCalendarDataWithTimeReverse,
 } from '../../utils/index';
+import Styleguide from '../StyleGuide/StyleGuide';
 import {
-  shouldCollapse,
-  shouldShowItem,
   getHeaderItemInfo,
   getKeyFromDateInfo,
   initializeProps,
+  shouldCollapse,
+  shouldShowItem,
 } from './Calendar.helper';
+import {
+  CalendarWrapperProps,
+  CurrentView,
+  DateInfoFunction,
+  PreparedDataWithTimeFull,
+  PreparedDataWithTimeInPlace,
+  PreparedDataWithoutTime,
+} from './Calendar.types';
 import CalendarComponent from './CalendarComponent';
-import Styleguide from '../StyleGuide/StyleGuide';
-import '../../styles/styles.scss';
 
 const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
   data,
@@ -51,6 +51,7 @@ const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
   timeDateFormat,
   weekStartsOn,
   locale,
+  todayLabel,
 }) => {
   // Preparing the data to work for all cases
   const {
@@ -69,6 +70,7 @@ const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
     dataModified,
     activeTimeDateFieldModified,
     localeModified,
+    todayLabelModified,
   } = initializeProps({
     cellDisplayMode,
     timeDateFormat,
@@ -85,6 +87,7 @@ const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
     activeTimeDateField,
     data,
     locale,
+    todayLabel,
   });
 
   const [hoveredElement, setHoveredElement] = React.useState(0);
@@ -410,6 +413,7 @@ const CalendarWrapper: React.FC<CalendarWrapperProps> = ({
         timeDateFormat={timeDateFormatModified}
         weekStartsOn={weekStartsOnModified}
         locale={localeModified}
+        todayLabel={todayLabelModified}
       />
     </>
   );


### PR DESCRIPTION
- Add a new prop `todayLabel` to customize the "Today" button displayed on top of the calendar.
- Update readme and storybook examples to include `locale` and `todayLabel` (since they are both related and `locale` was missing.

Closes #34 